### PR TITLE
fixed missing `django_vue_utilities` when drf not selected + added project_slug in vite docker service name

### DIFF
--- a/{{cookiecutter.project_slug}}/config/settings/base.py
+++ b/{{cookiecutter.project_slug}}/config/settings/base.py
@@ -92,10 +92,10 @@ THIRD_PARTY_APPS = [
     "rest_framework",
     "rest_framework.authtoken",
     "corsheaders",
+    "drf_spectacular",
+{%- endif %}
 {%- if cookiecutter.use_vue == "y" %}
     "django_vue_utilities",
-{%- endif %}
-    "drf_spectacular",
 {%- endif %}
 {%- if cookiecutter.frontend_pipeline == 'Webpack' %}
     "webpack_loader",

--- a/{{cookiecutter.project_slug}}/local.yml
+++ b/{{cookiecutter.project_slug}}/local.yml
@@ -135,8 +135,8 @@ services:
     build:
       context: .
       dockerfile: ./compose/local/vite/Dockerfile
-    image: my_awesome_vue_project_local_vite
-    container_name: my_awesome_vue_project_local_vite
+    image: {{ cookiecutter.project_slug }}_local_vite
+    container_name: {{ cookiecutter.project_slug }}_local_vite
     depends_on:
       - django
     volumes:


### PR DESCRIPTION
<!-- Thank you for helping us out: your efforts mean a great deal to the project and the community as a whole! -->

## Description

This fixes missing `django_vue_utilities` when drf not selected.
Also adds the `project_slug` prefix to the vite docker service name to avoid conflicts when multiple projects generated locally.

Checklist:

- [x] I've made sure that tests are updated accordingly (especially if adding or updating a template option)
- [x] I've updated the documentation or confirm that my change doesn't require any updates

